### PR TITLE
[2.0] Improvements in Uri::cleanPath()

### DIFF
--- a/src/AbstractUri.php
+++ b/src/AbstractUri.php
@@ -387,8 +387,8 @@ abstract class AbstractUri implements UriInterface
 	{
 		$path = preg_replace('#/+#', '/', $path);
 
-		// No dots in path no need to clean further, most used scenario.
-		if (strpos($path, './') === false)
+		// If no dots in path no need to clean further, most used scenario.
+		if (strpos($path, './') === false && substr($path, -1) !== '.')
 		{
 			return $path;
 		}


### PR DESCRIPTION
Pull Request for Improvement

### Introduction

The `Uri::cleanPath()` is used in all `JRoute::_()` calls in the cms (ex: building menus, breadcrumbs, sef, etc) so is a very used method (add `\JFactory::getApplication()->enqueueMessage($path, 'message');` to the begginng of the cleanPath() method to see that is used a lot).

This is used when the uri path is setted `Uri::setPath()` which happens a lot in the CMS.

Improving it's performance will do is little part in improving performance in the CMS.

As you will notice in the results there in not much change when the url uses parent relative paths, but that's not the most ususal usage, uri's without relative paths are processed 3x faster (see performance table below).

### Summary of Changes

Improves performance of Uri::cleanPath.
Also corrects some bugs (see exclamations points below).

### Testing Instructions

- Unit tests pass
- Code review
- To test use the following code in a cms 4.0 template index.php before and after the PR
- Test other urls you can remember and confirm all are with their paths cleaned
```php
$iterationsPerUrl = 1000;
$uriToTest = [
	// Without
	'',
	'foo',
	'foo/bar/',
	'foo/bar/file.php',
	'/',
	'/foo',
	'/foo/bar/',
	'/foo/bar/file.php',
	// Current
	'/.',
	'/./',
	'/./foo',
	'/./foo/bar/',
	'/./foo/./bar',
	// Parent
	'/..',
	'/../',
	'/../foo',
	'/../foo/bar/',
	'/../foo/../bar',
	// Mixed
	'/../foo/./bar',
	'/./foo/.././/bar/.',
	'/../foo/.././/bar/..',
	'/../foo/bar/.././/../file.php',
];

$uri = new \Joomla\Uri\Uri;
foreach ($uriToTest as $url)
{
	$start = microtime(true);
	for ($i = 1; $i <= $iterationsPerUrl; $i++)
	{
		$uri->setPath($url);
	}
	echo '- [' . number_format(((microtime(true) - $start) * 1000), 3) . ' ms] ' . $url . ' --- ' . $uri->getPath() . PHP_EOL;
}
```

My best results on PHP 7.0.19 in Linux for this urls parsed:

| Test | Result Before | Result After | Time Before | Time After |
| ------------- | ------------- | ------------- | ------------- | ------------- |
| Without relative paths | | | |
| (empty) | (empty) | (empty) | 1.009 ms | 0.313 ms |
| foo | foo | foo | 0.852 ms | 0.312 ms |
| foo/bar/ | foo/bar/ | foo/bar/ | 1.379 ms | 0.317 ms |
| foo/bar/file.php | foo/bar/file.php | foo/bar/file.php | 1.549 ms | 0.601 ms |
| / | / | / | 1.166 ms | 0.300 ms |
| /foo | /foo | /foo | 1.165 ms | 0.315 ms |
| /foo/bar/ | /foo/bar/ | /foo/bar/ | 1.773 ms | 0.328 ms |
| /foo/bar/file.php | /foo/bar/file.php | /foo/bar/file.php | 1.683 ms | 0.608 ms |
| With relative Paths (current) | | | | |
| /. | (empty) :exclamation: | / | 1.376 ms | 0.826 ms |
| /./ | / | / | 1.653 ms | 0.958 ms |
| /./foo | /foo | /foo | 1.839 ms | 1.080 ms |
| /./foo/bar/ | /foo/bar/ | /foo/bar/ | 2.170 ms | 1.012 ms |
| /./foo/./bar | /foo/bar | /foo/bar | 2.339 ms | 1.079 ms |
| With relative Paths (parent) | | | | |
| /.. | (empty) :exclamation: | / | 1.567 ms | 1.576 ms |
| /../ | / | / | 1.880 ms | 2.074 ms |
| /../foo | /foo | /foo | 1.877 ms | 2.138 ms |
| /../foo/bar/ | /foo/bar/ | /foo/bar/ | 2.387 ms | 2.428 ms |
| /../foo/../bar | /bar | /bar | 3.009 ms | 2.549 ms |
| With relative Paths (mixed) | | | | |
| /../foo/.././/bar | /bar | /bar | 3.422 ms | 3.469 ms |
| /./foo/.././/bar/. | /bar :exclamation: | /bar/ | 4.044 ms | 3.898 ms |
| /../foo/.././/bar/.. | (empty) :exclamation: | / | 4.091 ms | 3.785 ms |
| /../foo/bar/.././/../file.php | /file.php | /file.php | 4.288 ms | 4.028 ms |

### Documentation Changes Required

None.
